### PR TITLE
Handle initial container prompts and sudo fallback

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,8 +165,21 @@ fn install_like(arg: FileArg, cli: &Cli) -> Result<()> {
     // Install the package as root
     let install_cmd = build_install_cmd_root(&fmt, &in_box_path);
     println!("Installing inside box '{}'...", selected.name);
-    let ok = distro::enter_status(&selected.name, &install_cmd, true)?;
-    if !ok { return Err(anyhow!("installation command failed inside container")); }
+    let mut ok = distro::enter_status(&selected.name, &install_cmd, true)?;
+    if !ok {
+        // Fallback to using sudo/doas/non-root execution inside the container
+        let sudo_cmd = format!("sudo {}", install_cmd);
+        let doas_cmd = format!("doas {}", install_cmd);
+        for cmd in [&sudo_cmd, &doas_cmd, &install_cmd] {
+            if distro::enter_status(&selected.name, cmd, false)? {
+                ok = true;
+                break;
+            }
+        }
+    }
+    if !ok {
+        return Err(anyhow!("installation command failed inside container"));
+    }
     println!("Install completed.");
     if !cli.no_export {
         export_items(&selected.name, &bins, &apps)?;

--- a/src/distro.rs
+++ b/src/distro.rs
@@ -23,10 +23,7 @@ pub enum Family {
 /// - Fallback to `distrobox list` and attempt simple parsing.
 pub fn discover_boxes() -> Result<Vec<DistroBox>> {
     // Try JSON mode first
-    let json_out = Command::new("distrobox")
-        .arg("list")
-        .arg("--json")
-        .output();
+    let json_out = Command::new("distrobox").arg("list").arg("--json").output();
 
     if let Ok(out) = json_out {
         if out.status.success() {
@@ -40,7 +37,10 @@ pub fn discover_boxes() -> Result<Vec<DistroBox>> {
     }
 
     // Fallback to plain text
-    let out = Command::new("distrobox").arg("list").output().with_context(|| "running 'distrobox list'")?;
+    let out = Command::new("distrobox")
+        .arg("list")
+        .output()
+        .with_context(|| "running 'distrobox list'")?;
     if !out.status.success() {
         // Not found or error; return empty gracefully
         return Ok(vec![]);
@@ -68,14 +68,22 @@ fn parse_boxes_json(s: &str) -> Result<Vec<DistroBox>> {
         let arr: Vec<JsonBox> = serde_json::from_str(s)?;
         Ok(arr
             .into_iter()
-            .map(|j| DistroBox { name: j.name, image: j.image, runtime: j.engine.unwrap_or_else(|| "unknown".into()) })
+            .map(|j| DistroBox {
+                name: j.name,
+                image: j.image,
+                runtime: j.engine.unwrap_or_else(|| "unknown".into()),
+            })
             .collect())
     } else {
         let obj: JsonList = serde_json::from_str(s)?;
         Ok(obj
             .containers
             .into_iter()
-            .map(|j| DistroBox { name: j.name, image: j.image, runtime: j.engine.unwrap_or_else(|| "unknown".into()) })
+            .map(|j| DistroBox {
+                name: j.name,
+                image: j.image,
+                runtime: j.engine.unwrap_or_else(|| "unknown".into()),
+            })
             .collect())
     }
 }
@@ -88,45 +96,77 @@ fn parse_boxes_plain(s: &str) -> Vec<DistroBox> {
     let mut saw_pipe_header = false;
     for line in s.lines() {
         let t = line.trim();
-        if t.is_empty() { continue; }
+        if t.is_empty() {
+            continue;
+        }
 
         if t.contains('|') {
             // Pipe-separated table
             // Split and trim columns
             let mut cols: Vec<String> = t.split('|').map(|c| c.trim().to_string()).collect();
             // Skip header row
-            if cols.iter().any(|c| c.eq_ignore_ascii_case("NAME")) && cols.iter().any(|c| c.eq_ignore_ascii_case("ID")) {
+            if cols.iter().any(|c| c.eq_ignore_ascii_case("NAME"))
+                && cols.iter().any(|c| c.eq_ignore_ascii_case("ID"))
+            {
                 saw_pipe_header = true;
                 continue;
             }
             // Skip separators like "+---" if present
-            if cols.iter().all(|c| c.chars().all(|ch| ch == '-' || ch == '+')) { continue; }
+            if cols
+                .iter()
+                .all(|c| c.chars().all(|ch| ch == '-' || ch == '+'))
+            {
+                continue;
+            }
             if cols.len() >= 2 {
                 let name = cols.get(1).cloned().unwrap_or_default();
-                if name.is_empty() || name.eq_ignore_ascii_case("NAME") { continue; }
+                if name.is_empty() || name.eq_ignore_ascii_case("NAME") {
+                    continue;
+                }
                 let image = cols.get(3).cloned();
-                boxes.push(DistroBox { name, image, runtime: "unknown".into() });
+                boxes.push(DistroBox {
+                    name,
+                    image,
+                    runtime: "unknown".into(),
+                });
                 continue;
             }
         }
 
         // Fallback heuristic for plain whitespace formats
-        if t.starts_with("NAME") || t.starts_with("+---") || t.contains("CONTAINER ID") || t.eq_ignore_ascii_case("id") {
+        if t.starts_with("NAME")
+            || t.starts_with("+---")
+            || t.contains("CONTAINER ID")
+            || t.eq_ignore_ascii_case("id")
+        {
             continue;
         }
         let parts: Vec<&str> = t.split_whitespace().collect();
         if parts.len() >= 1 {
             // If we saw a pipe header earlier, the first column here is likely ID; skip such lines
-            if saw_pipe_header && parts.get(0).map(|c| c.len()).unwrap_or(0) >= 6 && parts.get(1).is_some() {
+            if saw_pipe_header
+                && parts.get(0).map(|c| c.len()).unwrap_or(0) >= 6
+                && parts.get(1).is_some()
+            {
                 // Likely an ID then NAME; take NAME
                 let name = parts.get(1).unwrap().to_string();
                 let image = parts.get(3).map(|s| s.to_string());
-                boxes.push(DistroBox { name, image, runtime: "unknown".into() });
+                boxes.push(DistroBox {
+                    name,
+                    image,
+                    runtime: "unknown".into(),
+                });
             } else {
                 let name = parts[0].to_string();
-                if name.eq_ignore_ascii_case("NAME") || name.eq_ignore_ascii_case("Created") { continue; }
+                if name.eq_ignore_ascii_case("NAME") || name.eq_ignore_ascii_case("Created") {
+                    continue;
+                }
                 let image = parts.get(1).map(|s| s.to_string());
-                boxes.push(DistroBox { name, image, runtime: "unknown".into() });
+                boxes.push(DistroBox {
+                    name,
+                    image,
+                    runtime: "unknown".into(),
+                });
             }
         }
     }
@@ -136,11 +176,21 @@ fn parse_boxes_plain(s: &str) -> Vec<DistroBox> {
 /// Classify a Distrobox into a Linux distribution family by reading /etc/os-release inside it.
 pub fn classify_box_family(name: &str) -> Result<Family> {
     let out = Command::new("distrobox")
-        .args(["enter", "-n", name, "--", "sh", "-lc", "cat /etc/os-release 2>/dev/null || true"])
+        .args([
+            "enter",
+            "-n",
+            name,
+            "--",
+            "sh",
+            "-lc",
+            "cat /etc/os-release 2>/dev/null || true",
+        ])
         .output()
         .with_context(|| format!("running 'distrobox enter' for {name}"))?;
     if !out.status.success() {
-        return Err(anyhow!("failed to enter box {name} to read /etc/os-release"));
+        return Err(anyhow!(
+            "failed to enter box {name} to read /etc/os-release"
+        ));
     }
     let text = String::from_utf8_lossy(&out.stdout);
     let (id, id_like) = parse_os_release(text.as_ref());
@@ -152,7 +202,9 @@ fn parse_os_release(s: &str) -> (Option<String>, Vec<String>) {
     let mut id_like: Vec<String> = Vec::new();
     for line in s.lines() {
         let line = line.trim();
-        if line.is_empty() || line.starts_with('#') { continue; }
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
         if let Some(rest) = line.strip_prefix("ID=") {
             id = Some(unquote(rest).to_ascii_lowercase());
         } else if let Some(rest) = line.strip_prefix("ID_LIKE=") {
@@ -167,18 +219,30 @@ fn unquote(s: &str) -> String {
     let t = s.trim();
     if (t.starts_with('"') && t.ends_with('"')) || (t.starts_with('\'') && t.ends_with('\'')) {
         t[1..t.len().saturating_sub(1)].to_string()
-    } else { t.to_string() }
+    } else {
+        t.to_string()
+    }
 }
 
 fn classify_ids(id: &Option<String>, id_like: &Vec<String>) -> Option<Family> {
     let mut tokens: Vec<String> = Vec::new();
-    if let Some(i) = id { tokens.push(i.clone()); }
+    if let Some(i) = id {
+        tokens.push(i.clone());
+    }
     tokens.extend(id_like.clone());
     let has = |k: &str| tokens.iter().any(|t| t == k);
-    if has("debian") || has("ubuntu") { return Some(Family::Debian); }
-    if has("fedora") || has("rhel") || has("centos") { return Some(Family::Fedora); }
-    if has("opensuse") || has("sles") || has("suse") { return Some(Family::OpenSuse); }
-    if has("arch") || has("manjaro") || has("endeavouros") { return Some(Family::Arch); }
+    if has("debian") || has("ubuntu") {
+        return Some(Family::Debian);
+    }
+    if has("fedora") || has("rhel") || has("centos") {
+        return Some(Family::Fedora);
+    }
+    if has("opensuse") || has("sles") || has("suse") {
+        return Some(Family::OpenSuse);
+    }
+    if has("arch") || has("manjaro") || has("endeavouros") {
+        return Some(Family::Arch);
+    }
     None
 }
 
@@ -198,38 +262,81 @@ pub fn create_box(name: &str, image: &str) -> Result<()> {
 pub fn enter_capture(name: &str, cmd: &str, as_root: bool) -> Result<std::process::Output> {
     let mut c = Command::new("distrobox");
     c.arg("enter");
-    if as_root { c.arg("--root"); }
+    if as_root {
+        c.arg("--root");
+    }
     c.args(["-n", name, "--", "sh", "-lc", cmd]);
-    let out = c.output().with_context(|| format!("entering box {name} to run: {cmd}"))?;
+    let out = c
+        .output()
+        .with_context(|| format!("entering box {name} to run: {cmd}"))?;
     Ok(out)
 }
 
 /// Run a command inside a distrobox and return exit status only
 pub fn enter_status(name: &str, cmd: &str, as_root: bool) -> Result<bool> {
-    let out = enter_capture(name, cmd, as_root)?;
-    Ok(out.status.success())
+    let mut c = Command::new("distrobox");
+    c.arg("enter");
+    if as_root {
+        c.arg("--root");
+    }
+    c.args(["-n", name, "--", "sh", "-lc", cmd]);
+    // Inherit stdio so that interactive prompts (passwords, confirmations) are
+    // forwarded directly to the user. Using `status()` avoids capturing output
+    // and allows the child process to interact with the terminal.
+    let status = c
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| format!("entering box {name} to run: {cmd}"))?;
+    Ok(status.success())
 }
 
 /// Copy a local file into the box at /tmp/pkgbridge/<sanitized-basename> via stdin piping.
 /// Returns the destination path inside the container.
 pub fn copy_into_box(name: &str, local_path: &std::path::Path) -> Result<String> {
-    let data = std::fs::read(local_path).with_context(|| format!("reading {}", local_path.display()))?;
+    let data =
+        std::fs::read(local_path).with_context(|| format!("reading {}", local_path.display()))?;
     let base = local_path
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("package");
     let mut sanitized = String::new();
     for ch in base.chars() {
-        if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_' { sanitized.push(ch); } else { sanitized.push('_'); }
+        if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_' {
+            sanitized.push(ch);
+        } else {
+            sanitized.push('_');
+        }
     }
-    if sanitized.is_empty() { sanitized.push_str("package"); }
+    if sanitized.is_empty() {
+        sanitized.push_str("package");
+    }
     let dest = format!("/tmp/pkgbridge/{sanitized}");
     let quoted = shell_escape::escape(std::borrow::Cow::from(dest.clone()));
     let cmd = format!("mkdir -p /tmp/pkgbridge && cat > {quoted}");
 
+    // Ensure the container is initialized before piping data. This forwards
+    // any first-time setup prompts (e.g. password creation) to the user so
+    // they can be handled interactively.
+    let init = Command::new("distrobox")
+        .arg("enter")
+        .arg("-n")
+        .arg(name)
+        .args(["--", "true"])
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| format!("initializing box {name}"))?;
+    if !init.success() {
+        return Err(anyhow!("initializing container failed"));
+    }
+
     let mut child = Command::new("distrobox")
         .arg("enter")
-        .arg("-n").arg(name)
+        .arg("-n")
+        .arg(name)
         .args(["--", "sh", "-lc", &cmd])
         .stdin(Stdio::piped())
         .spawn()

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -1,5 +1,5 @@
-use crate::distro::Family;
 use crate::config;
+use crate::distro::Family;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
@@ -8,7 +8,8 @@ use which::which;
 
 pub fn set_default(fam: Family, box_name: &str) -> Result<()> {
     let mut cfg = config::load_config();
-    cfg.pm_defaults.insert(family_key(fam).into(), box_name.to_string());
+    cfg.pm_defaults
+        .insert(family_key(fam).into(), box_name.to_string());
     config::save_config(&cfg)
 }
 
@@ -19,7 +20,9 @@ pub fn show_defaults() -> HashMap<String, String> {
 pub fn generate_shims() -> Result<()> {
     let cfg = config::load_config();
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-    let bindir: PathBuf = std::env::var("XDG_BIN_HOME").map(PathBuf::from).unwrap_or_else(|_| PathBuf::from(format!("{home}/.local/bin")));
+    let bindir: PathBuf = std::env::var("XDG_BIN_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(format!("{home}/.local/bin")));
     fs::create_dir_all(&bindir).ok();
     for (fam_key, box_name) in cfg.pm_defaults.iter() {
         match fam_key.as_str() {
@@ -46,10 +49,11 @@ pub fn write_shim(dir: &PathBuf, name: &str, box_name: &str, fam_key: &str) -> R
     let path = dir.join(name);
     // Try to run the package manager as root inside the container.
     // Fallbacks: attempt with sudo/doas inside container, then non-root (may fail for ops requiring privileges).
-    let content = format!("#!/usr/bin/env sh\nset -e\nbox=\"{}\"\nfam=\"{}\"\n# Pre-transaction snapshot\npkgbridge pm snapshot --family \"$fam\" --container \"$box\" >/dev/null 2>&1 || true\nstatus=0\nif distrobox enter --root -n \"$box\" -- true >/dev/null 2>&1; then\n  distrobox enter --root -n \"$box\" -- {} \"$@\" || status=$?\nelse\n  if distrobox enter -n \"$box\" -- sudo -n true >/dev/null 2>&1; then\n    distrobox enter -n \"$box\" -- sudo -n {} \"$@\" || status=$?\n  elif distrobox enter -n \"$box\" -- doas true >/dev/null 2>&1; then\n    distrobox enter -n \"$box\" -- doas {} \"$@\" || status=$?\n  else\n    distrobox enter -n \"$box\" -- {} \"$@\" || status=$?\n  fi\nfi\n# Post-transaction export\npkgbridge pm post-transaction --family \"$fam\" --container \"$box\" >/dev/null 2>&1 || true\nexit $status\n", box_name, fam_key, name, name, name, name);
+    let content = format!("#!/usr/bin/env sh\nset -e\nbox=\"{}\"\nfam=\"{}\"\n# Pre-transaction snapshot\npkgbridge pm snapshot --family \"$fam\" --container \"$box\" >/dev/null 2>&1 || true\nstatus=0\nif distrobox enter --root -n \"$box\" -- true >/dev/null 2>&1; then\n  distrobox enter --root -n \"$box\" -- {} \"$@\" || status=$?\nelse\n  if distrobox enter -n \"$box\" -- command -v sudo >/dev/null 2>&1; then\n    distrobox enter -n \"$box\" -- sudo {} \"$@\" || status=$?\n  elif distrobox enter -n \"$box\" -- command -v doas >/dev/null 2>&1; then\n    distrobox enter -n \"$box\" -- doas {} \"$@\" || status=$?\n  else\n    distrobox enter -n \"$box\" -- {} \"$@\" || status=$?\n  fi\nfi\n# Post-transaction export\npkgbridge pm post-transaction --family \"$fam\" --container \"$box\" >/dev/null 2>&1 || true\nexit $status\n", box_name, fam_key, name, name, name, name);
     fs::write(&path, content).with_context(|| format!("writing {}", path.display()))?;
     let mut perms = fs::metadata(&path)?.permissions();
-    #[cfg(unix)] {
+    #[cfg(unix)]
+    {
         use std::os::unix::fs::PermissionsExt;
         perms.set_mode(0o755);
         fs::set_permissions(&path, perms)?;
@@ -58,10 +62,20 @@ pub fn write_shim(dir: &PathBuf, name: &str, box_name: &str, fam_key: &str) -> R
 }
 
 pub fn family_key(f: Family) -> &'static str {
-    match f { Family::Debian => "debian", Family::Fedora => "fedora", Family::OpenSuse => "opensuse", Family::Arch => "arch" }
+    match f {
+        Family::Debian => "debian",
+        Family::Fedora => "fedora",
+        Family::OpenSuse => "opensuse",
+        Family::Arch => "arch",
+    }
 }
 
-fn generate_shim_with_policy(bindir: &PathBuf, name: &str, box_name: &str, fam_key: &str) -> Result<()> {
+fn generate_shim_with_policy(
+    bindir: &PathBuf,
+    name: &str,
+    box_name: &str,
+    fam_key: &str,
+) -> Result<()> {
     // If the host already has this package manager (and it's not our own shim in bindir),
     // avoid overshadowing it. Instead, create a suffixed wrapper like "apt-<box>".
     let host_has = host_has_cmd_outside_bindir(name, bindir);
@@ -105,6 +119,12 @@ fn host_has_cmd_outside_bindir(cmd: &str, bindir: &PathBuf) -> bool {
 
 fn sanitize(s: &str) -> String {
     s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect()
 }


### PR DESCRIPTION
## Summary
- ensure first container entry prompts are shown by initializing boxes before file copy
- add sudo/doas fallback when installing packages in a box

## Testing
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_b_68b807f01b34832c9d947ac2730edff4